### PR TITLE
[Airflow] Updates the option 'server-uri' to 'notification-server-uri' for the Airflow webserver

### DIFF
--- a/ai_flow_plugins/scheduler_plugins/airflow/airflow_scheduler.py
+++ b/ai_flow_plugins/scheduler_plugins/airflow/airflow_scheduler.py
@@ -101,7 +101,7 @@ class AirFlowSchedulerBase(Scheduler, ABC):
     @property
     def airflow_client(self):
         if self._airflow_client is None:
-            self._airflow_client = EventSchedulerClient(server_uri=self.config.get('notification_service_uri'),
+            self._airflow_client = EventSchedulerClient(notification_server_uri=self.config.get('notification_service_uri'),
                                                         namespace=SCHEDULER_NAMESPACE)
         return self._airflow_client
 

--- a/bin/start-airflow.sh
+++ b/bin/start-airflow.sh
@@ -92,13 +92,13 @@ init_airflow_config "$MYSQL_CONN"
 
 echo "Starting Airflow Scheduler"
 SCHEDULER_LOG_FILE_NAME=scheduler-$(date "+%Y%m%d-%H%M%S").log
-airflow event_scheduler --subdir="${AIRFLOW_DAG_DIR}" --server-uri="${NOTIFICATION_SERVER_URI}" > "${AIRFLOW_LOG_DIR}"/"${SCHEDULER_LOG_FILE_NAME}" 2>&1 &
+airflow event_scheduler --subdir="${AIRFLOW_DAG_DIR}" --notification-server-uri="${NOTIFICATION_SERVER_URI}" > "${AIRFLOW_LOG_DIR}"/"${SCHEDULER_LOG_FILE_NAME}" 2>&1 &
 echo $! > "${AIRFLOW_PID_DIR}"/scheduler.pid
 echo "Airflow Scheduler started"
 
 echo "Starting Airflow Web Server"
 WEB_SERVER_LOG_FILE_NAME=web-$(date "+%Y%m%d-%H%M%S").log
-airflow webserver -p 8080 --server-uri="${NOTIFICATION_SERVER_URI}" > "${AIRFLOW_LOG_DIR}"/"${WEB_SERVER_LOG_FILE_NAME}" 2>&1 &
+airflow webserver -p 8080 --notification-server-uri="${NOTIFICATION_SERVER_URI}" > "${AIRFLOW_LOG_DIR}"/"${WEB_SERVER_LOG_FILE_NAME}" 2>&1 &
 echo $! > "${AIRFLOW_PID_DIR}"/web.pid
 wait_for_airflow_web_server "${WEB_SERVER_LOG_FILE_NAME}"
 echo "Airflow Web Server started"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -505,7 +505,7 @@ scheduler:
   # Command to use when running the Airflow scheduler (templated).
   command: ~
   # Args to use when running the Airflow scheduler (templated).
-  args: ["bash", "-c", "start-aiflow.sh && python -c 'from airflow.utils.serve_logs import serve_logs;serve_logs()' > /var/log/serve_log.log 2>&1 & exec airflow event_scheduler --subdir={{ .Values.ai_flow.airflow_deploy_path }} --server-uri={{ .Release.Name }}-notification:50052"]
+  args: ["bash", "-c", "start-aiflow.sh && python -c 'from airflow.utils.serve_logs import serve_logs;serve_logs()' > /var/log/serve_log.log 2>&1 & exec airflow event_scheduler --subdir={{ .Values.ai_flow.airflow_deploy_path }} --notification-server-uri={{ .Release.Name }}-notification:50052"]
 
   # Update Strategy when scheduler is deployed as a StatefulSet
   # (when using LocalExecutor and workers.persistence)
@@ -646,7 +646,7 @@ webserver:
   # Command to use when running the Airflow webserver (templated).
   command: ~
   # Args to use when running the Airflow webserver (templated).
-  args: ["bash", "-c", "exec airflow webserver --server-uri={{ .Release.Name }}-notification:50052"]
+  args: ["bash", "-c", "exec airflow webserver --notification-server-uri={{ .Release.Name }}-notification:50052"]
 
   # Create ServiceAccount
   serviceAccount:

--- a/lib/airflow/airflow/cli/cli_parser.py
+++ b/lib/airflow/airflow/cli/cli_parser.py
@@ -147,8 +147,8 @@ ARG_SUBDIR = Arg(
     ),
     default='[AIRFLOW_HOME]/dags' if BUILD_DOCS else settings.DAGS_FOLDER,
 )
-ARG_SERVER_URI = Arg(
-    ("--server-uri",),
+ARG_NOTIFICATION_SERVER_URI = Arg(
+    ("--notification-server-uri",),
     help=(
         "Notification service server uri."
     ),
@@ -985,7 +985,7 @@ TASKS_COMMANDS = (
             ARG_JOB_ID,
             ARG_INTERACTIVE,
             ARG_SHUT_DOWN_LOGGING,
-            ARG_SERVER_URI,
+            ARG_NOTIFICATION_SERVER_URI,
             ARG_DAG_SHA1_HASH,
             ARG_LOAD_DAG_FROM_DB
         ),
@@ -1447,7 +1447,7 @@ airflow_commands: List[CLICommand] = [
             ARG_SSL_CERT,
             ARG_SSL_KEY,
             ARG_DEBUG,
-            ARG_SERVER_URI,
+            ARG_NOTIFICATION_SERVER_URI
         ),
     ),
     ActionCommand(
@@ -1463,7 +1463,7 @@ airflow_commands: List[CLICommand] = [
             ARG_STDOUT,
             ARG_STDERR,
             ARG_LOG_FILE,
-            ARG_SERVER_URI,
+            ARG_NOTIFICATION_SERVER_URI,
         ),
         epilog=(
             'Signals:\n'
@@ -1480,7 +1480,7 @@ airflow_commands: List[CLICommand] = [
         func=lazy_load_command('airflow.cli.commands.event_based_scheduler_command.event_based_scheduler'),
         args=(
             ARG_SUBDIR,
-            ARG_SERVER_URI,
+            ARG_NOTIFICATION_SERVER_URI,
             ARG_EVENT_START_TIME,
             ARG_NUM_RUNS,
             ARG_DO_PICKLE,

--- a/lib/airflow/airflow/cli/commands/event_based_scheduler_command.py
+++ b/lib/airflow/airflow/cli/commands/event_based_scheduler_command.py
@@ -33,7 +33,7 @@ def event_based_scheduler(args):
     print(settings.HEADER)
     job = EventBasedSchedulerJob(
         dag_directory=process_subdir(args.subdir),
-        server_uri=args.server_uri,
+        notification_server_uri=args.notification_server_uri,
         event_start_time=args.event_start_time
     )
 

--- a/lib/airflow/airflow/cli/commands/scheduler_command.py
+++ b/lib/airflow/airflow/cli/commands/scheduler_command.py
@@ -44,7 +44,7 @@ def scheduler(args):
     elif scheduler_name == SchedulerFactory.EVENT_BASED_SCHEDULER:
         job = EventBasedSchedulerJob(
             dag_directory=process_subdir(args.subdir),
-            server_uri=args.server_uri)
+            notification_server_uri=args.notification_server_uri)
     else:
         scheduler_class = SchedulerFactory.get_default_scheduler()
         job = scheduler_class()

--- a/lib/airflow/airflow/cli/commands/task_command.py
+++ b/lib/airflow/airflow/cli/commands/task_command.py
@@ -116,7 +116,7 @@ def _run_task_by_local_task_job(args, ti):
         ignore_task_deps=args.ignore_dependencies,
         ignore_ti_state=args.force,
         pool=args.pool,
-        server_uri=args.server_uri
+        notification_server_uri=args.notification_server_uri
     )
     try:
         run_job.run()
@@ -151,7 +151,7 @@ def _run_raw_task(args, ti):
         mark_success=args.mark_success,
         job_id=args.job_id,
         pool=args.pool,
-        notification_server_uri=args.server_uri
+        notification_server_uri=args.notification_server_uri
     )
 
 

--- a/lib/airflow/airflow/cli/commands/webserver_command.py
+++ b/lib/airflow/airflow/cli/commands/webserver_command.py
@@ -344,7 +344,8 @@ def webserver(args):
 
     if args.debug:
         print(f"Starting the web server on port {args.port} and host {args.hostname}.")
-        app = create_app(testing=conf.getboolean('core', 'unit_test_mode'), server_uri=args.server_uri)
+        app = create_app(testing=conf.getboolean('core', 'unit_test_mode'),
+                         notification_server_uri=args.notification_server_uri)
         app.run(
             debug=True,
             use_reloader=not app.config['TESTING'],
@@ -452,7 +453,7 @@ def webserver(args):
                 ),
             ).start()
 
-        os.environ['SERVER_URI'] = args.server_uri
+        os.environ['NOTIFICATION_SERVER_URI'] = args.notification_server_uri
 
         if args.daemon:
             handle = setup_logging(log_file)

--- a/lib/airflow/airflow/contrib/jobs/scheduler_client.py
+++ b/lib/airflow/airflow/contrib/jobs/scheduler_client.py
@@ -48,9 +48,9 @@ class ResponseWatcher(EventWatcher):
 
 
 class EventSchedulerClient(object):
-    def __init__(self, server_uri=None, namespace=None, ns_client=None):
+    def __init__(self, notification_server_uri=None, namespace=None, ns_client=None):
         if ns_client is None:
-            self.ns_client = NotificationClient(server_uri, namespace)
+            self.ns_client = NotificationClient(notification_server_uri, namespace)
         else:
             self.ns_client = ns_client
 

--- a/lib/airflow/airflow/executors/base_executor.py
+++ b/lib/airflow/airflow/executors/base_executor.py
@@ -71,13 +71,13 @@ class BaseExecutor(LoggingMixin):
         self.running: Set[TaskInstanceKey] = set()
         self.event_buffer: Dict[TaskInstanceKey, EventBufferValueType] = {}
         self._mailbox = None
-        self._server_uri = None
+        self._notification_server_uri = None
 
     def set_mailbox(self, mailbox):
         self._mailbox = mailbox
 
-    def set_server_uri(self, server_uri):
-        self._server_uri = server_uri
+    def notification_server_uri(self, notification_server_uri):
+        self._notification_server_uri = notification_server_uri
 
     def start(self):  # pragma: no cover
         """Executors may need to get things started."""
@@ -188,7 +188,7 @@ class BaseExecutor(LoggingMixin):
             pool=ti.pool,
             file_path=ti.dag_model.fileloc,
             pickle_id=ti.dag_model.pickle_id,
-            server_uri=self._server_uri,
+            notification_server_uri=self._notification_server_uri,
         )
         if ti.is_active is False:
             ti.reset_to_active()

--- a/lib/airflow/airflow/jobs/local_task_job.py
+++ b/lib/airflow/airflow/jobs/local_task_job.py
@@ -50,7 +50,7 @@ class LocalTaskJob(BaseJob):
         mark_success: bool = False,
         pickle_id: Optional[str] = None,
         pool: Optional[str] = None,
-        server_uri: str = None,
+        notification_server_uri: str = None,
         *args,
         **kwargs,
     ):
@@ -64,7 +64,7 @@ class LocalTaskJob(BaseJob):
         self.pickle_id = pickle_id
         self.mark_success = mark_success
         self.task_runner = None
-        self.server_uri = server_uri
+        self.notification_server_uri = notification_server_uri
 
         # terminating state is used so that a job don't try to
         # terminate multiple times
@@ -98,11 +98,11 @@ class LocalTaskJob(BaseJob):
             return
 
         try:
-            if self.server_uri is not None:
+            if self.notification_server_uri is not None:
                 try:
                     self._send_task_status_change_event()
                 except Exception as e:
-                    self.log.warning("failed to send event to {}".format(self.server_uri), exc_info=e)
+                    self.log.warning("failed to send event to {}".format(self.notification_server_uri), exc_info=e)
             self.task_runner.start()
 
             heartbeat_time_limit = conf.getint('scheduler', 'scheduler_zombie_task_threshold')
@@ -153,7 +153,7 @@ class LocalTaskJob(BaseJob):
                 self.task_instance.try_number
             )
             event = task_status_changed_event.to_event()
-            client = NotificationClient(self.server_uri, default_namespace=event.namespace, sender=event.sender)
+            client = NotificationClient(self.notification_server_uri, default_namespace=event.namespace, sender=event.sender)
             self.log.info("LocalTaskJob sending event: {}".format(event))
             client.send_event(event)
         finally:

--- a/lib/airflow/airflow/models/taskinstance.py
+++ b/lib/airflow/airflow/models/taskinstance.py
@@ -384,7 +384,7 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
             job_id=job_id,
             pool=pool,
             cfg_path=cfg_path,
-            server_uri=notification_server_uri
+            notification_server_uri=notification_server_uri
         )
 
     @staticmethod
@@ -404,7 +404,7 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
         job_id: Optional[str] = None,
         pool: Optional[str] = None,
         cfg_path: Optional[str] = None,
-        server_uri: Optional[str] = None,
+        notification_server_uri: Optional[str] = None,
     ) -> List[str]:
         """
         Generates the shell command required to execute this task instance.
@@ -443,8 +443,8 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
         :type pool: Optional[str]
         :param cfg_path: the Path to the configuration file
         :type cfg_path: Optional[str]
-        :param server_uri: the notification server uri
-        :type server_uri: Optional[str]
+        :param notification_server_uri: the notification server uri
+        :type notification_server_uri: Optional[str]
         :return: shell command that can be used to run the task instance
         :rtype: list[str]
         """
@@ -474,8 +474,8 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
             cmd.extend(["--subdir", file_path])
         if cfg_path:
             cmd.extend(["--cfg-path", cfg_path])
-        if server_uri:
-            cmd.extend(["--server-uri", server_uri])
+        if notification_server_uri:
+            cmd.extend(["--notification-server-uri", notification_server_uri])
         return cmd
 
     @property

--- a/lib/airflow/airflow/task/task_runner/base_task_runner.py
+++ b/lib/airflow/airflow/task/task_runner/base_task_runner.py
@@ -89,7 +89,7 @@ class BaseTaskRunner(LoggingMixin):
             job_id=local_task_job.id,
             pool=local_task_job.pool,
             cfg_path=cfg_path,
-            notification_server_uri=local_task_job.server_uri
+            notification_server_uri=local_task_job.notification_server_uri
         )
         self.process = None
 

--- a/lib/airflow/airflow/www/app.py
+++ b/lib/airflow/airflow/www/app.py
@@ -66,7 +66,7 @@ def sync_appbuilder_roles(flask_app):
         security_manager.sync_resource_permissions()
 
 
-def create_app(config=None, testing=False, app_name="Airflow", server_uri=None):
+def create_app(config=None, testing=False, app_name="Airflow", notification_server_uri=None):
     """Create a new instance of Airflow WWW app"""
     flask_app = Flask(__name__)
     flask_app.secret_key = conf.get('webserver', 'SECRET_KEY')
@@ -113,7 +113,7 @@ def create_app(config=None, testing=False, app_name="Airflow", server_uri=None):
     with flask_app.app_context():
         init_appbuilder(flask_app)
 
-        init_appbuilder_views(flask_app, server_uri)
+        init_appbuilder_views(flask_app, notification_server_uri)
         init_appbuilder_links(flask_app)
         init_plugins(flask_app)
         init_connection_form()
@@ -133,5 +133,6 @@ def cached_app(config=None, testing=False):
     """Return cached instance of Airflow WWW app"""
     global app  # pylint: disable=global-statement
     if not app:
-        app = create_app(config=config, testing=testing, server_uri=os.getenv('SERVER_URI',  None))
+        app = create_app(config=config, testing=testing,
+                         notification_server_uri=os.getenv('NOTIFICATION_SERVER_URI',  None))
     return app

--- a/lib/airflow/airflow/www/extensions/init_views.py
+++ b/lib/airflow/airflow/www/extensions/init_views.py
@@ -41,7 +41,7 @@ def init_flash_views(app):
     app.register_blueprint(routes)
 
 
-def init_appbuilder_views(app, server_uri):
+def init_appbuilder_views(app, notification_server_uri):
     """Initialize Web UI views"""
     appbuilder = app.appbuilder
     from airflow.www import views
@@ -50,7 +50,7 @@ def init_appbuilder_views(app, server_uri):
     # reusing a session with a disconnected connection
     appbuilder.session.remove()
     appbuilder.add_view_no_menu(views.DagModelView())
-    appbuilder.add_view_no_menu(views.Airflow(server_uri))
+    appbuilder.add_view_no_menu(views.Airflow(notification_server_uri))
     appbuilder.add_view(
         views.DagRunModelView,
         permissions.RESOURCE_DAG_RUN,

--- a/lib/airflow/airflow/www/views.py
+++ b/lib/airflow/airflow/www/views.py
@@ -435,10 +435,11 @@ class AirflowBaseView(BaseView):  # noqa: D101
 class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-methods
     """Main Airflow application."""
 
-    def __init__(self, server_uri=None, **kwargs):
+    def __init__(self, notification_server_uri=None, **kwargs):
         super().__init__(**kwargs)
-        if server_uri:
-            self.notification_client: NotificationClient = NotificationClient(server_uri, SCHEDULER_NAMESPACE)
+        if notification_server_uri:
+            self.notification_client: NotificationClient = NotificationClient(notification_server_uri,
+                                                                              SCHEDULER_NAMESPACE)
 
     @expose('/health')
     def health(self):

--- a/lib/airflow/tests/contrib/jobs/test_event_based_scheduler.py
+++ b/lib/airflow/tests/contrib/jobs/test_event_based_scheduler.py
@@ -166,7 +166,7 @@ class TestEventBasedScheduler(unittest.TestCase):
     def start_scheduler(self, file_path, event_start_time=int(time.time()*1000)):
         self.scheduler = EventBasedSchedulerJob(
             dag_directory=file_path,
-            server_uri="localhost:{}".format(self.port),
+            notification_server_uri="localhost:{}".format(self.port),
             event_start_time=event_start_time,
             executor=LocalExecutor(3),
             max_runs=-1,
@@ -613,7 +613,7 @@ class TestEventBasedScheduler(unittest.TestCase):
         dag_file = os.path.join(TEST_DAG_FOLDER, 'test_dag_context_extractor.py')
         scheduler = EventBasedSchedulerJob(
             dag_directory=dag_file,
-            server_uri="localhost:{}".format(self.port),
+            notification_server_uri="localhost:{}".format(self.port),
             executor=LocalExecutor(3),
             max_runs=-1,
             refresh_dag_dir_interval=30
@@ -643,7 +643,7 @@ class TestEventBasedScheduler(unittest.TestCase):
         dag_file = os.path.join(TEST_DAG_FOLDER, 'test_dag_context_extractor_throw_exception.py')
         scheduler = EventBasedSchedulerJob(
             dag_directory=dag_file,
-            server_uri="localhost:{}".format(self.port),
+            notification_server_uri="localhost:{}".format(self.port),
             executor=LocalExecutor(3),
             max_runs=-1,
             refresh_dag_dir_interval=30
@@ -667,7 +667,7 @@ class TestEventBasedScheduler(unittest.TestCase):
         dag_file = os.path.join(TEST_DAG_FOLDER, 'test_event_based_executor.py')
         scheduler = EventBasedSchedulerJob(
             dag_directory=dag_file,
-            server_uri="localhost:{}".format(self.port),
+            notification_server_uri="localhost:{}".format(self.port),
             executor=LocalExecutor(3),
             max_runs=-1,
             refresh_dag_dir_interval=30


### PR DESCRIPTION
## What is the purpose of the change

The Airflow option `server-uri` is confusing in `event_scheduler` and `webserver` command, which could be replaced with `notification-server-uri`.