### PR TITLE
[plugin] AirFlowScheduler get airflow_deploy_path from airflow config if not set

### DIFF
--- a/ai_flow/config_templates/default_aiflow_server.yaml
+++ b/ai_flow/config_templates/default_aiflow_server.yaml
@@ -49,7 +49,9 @@ scheduler_service:
   scheduler:
     scheduler_class: ai_flow_plugins.scheduler_plugins.airflow.airflow_scheduler.AirFlowScheduler
     scheduler_config:
-      # AirFlow dag file deployment directory, i.e., where the airflow dag will be.
-      airflow_deploy_path: {AIRFLOW_DAG_DIR}
+      # AirFlow dag file deployment directory, i.e., where the airflow dag will be. If it is not set, the dags_folder in
+      # airflow config will be used
+      #airflow_deploy_path: /tmp/dags
+
       # Notification service uri used by the AirFlowScheduler.
       notification_service_uri: {NOTIFICATION_SERVER_URI}


### PR DESCRIPTION



<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

AirFlowScheduler get airflow_deploy_path from airflow config if not set


## Brief change log


* [plugin] AirFlowScheduler get airflow_deploy_path from airflow config if not set

* [plugin] Update default_aiflow_server.yaml

(cherry picked from commit 3bf7b8c37f953a21036c89e7703736ece2491777)


## Verifying this change

This change added tests.