### PR TITLE
[Airflow] Avoid passing config to gunicorn worker with environment variable

### DIFF
--- a/lib/airflow/airflow/www/app.py
+++ b/lib/airflow/airflow/www/app.py
@@ -130,11 +130,11 @@ def create_app(config=None, testing=False, app_name="Airflow", notification_serv
     return flask_app
 
 
-def cached_app(config=None, testing=False):
+def cached_app(config=None, testing=False, notification_server_uri=None, notification_sql_alchemy_conn=None):
     """Return cached instance of Airflow WWW app"""
     global app  # pylint: disable=global-statement
     if not app:
         app = create_app(config=config, testing=testing,
-                         notification_server_uri=os.getenv('NOTIFICATION_SERVER_URI', None),
-                         notification_sql_alchemy_conn=os.getenv('NOTIFICATION_SQL_ALCHEMY_CONN', None))
+                         notification_server_uri=notification_server_uri,
+                         notification_sql_alchemy_conn=notification_sql_alchemy_conn)
     return app


### PR DESCRIPTION

<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change
Avoid passing config to gunicorn worker with environment variable



## Brief change log

cherry picked from commit 6b7b8b13d447b636de7951abcb69657623af192b


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
