### PR TITLE
Set the maximum message length that the NotificationClient can receiv…

### DIFF
--- a/lib/notification_service/java/src/main/java/org/aiflow/notification/client/NotificationClient.java
+++ b/lib/notification_service/java/src/main/java/org/aiflow/notification/client/NotificationClient.java
@@ -43,6 +43,8 @@ import static org.aiflow.notification.conf.Configuration.CLIENT_ID_CONFIG_DEFAUL
 import static org.aiflow.notification.conf.Configuration.CLIENT_ID_CONFIG_KEY;
 import static org.aiflow.notification.conf.Configuration.CLIENT_INITIAL_SEQUENCE_NUMBER_CONFIG_DEFAULT_VALUE;
 import static org.aiflow.notification.conf.Configuration.CLIENT_INITIAL_SEQUENCE_NUMBER_CONFIG_KEY;
+import static org.aiflow.notification.conf.Configuration.GRPC_MAX_RECEIVE_MESSAGE_LENGTH_CONFIG_DEFAULT_VALUE;
+import static org.aiflow.notification.conf.Configuration.GRPC_MAX_RECEIVE_MESSAGE_LENGTH_CONFIG_KEY;
 
 public class NotificationClient {
 
@@ -262,6 +264,10 @@ public class NotificationClient {
 
     /** Initialize notification service stub. */
     protected void initNotificationServiceStub() {
+        int maxMessageSize =
+                this.conf.getInt(
+                        GRPC_MAX_RECEIVE_MESSAGE_LENGTH_CONFIG_KEY,
+                        GRPC_MAX_RECEIVE_MESSAGE_LENGTH_CONFIG_DEFAULT_VALUE);
         if (notificationServiceStub == null) {
             notificationServiceStub =
                     NotificationServiceGrpc.newBlockingStub(
@@ -269,6 +275,7 @@ public class NotificationClient {
                                             StringUtils.isEmpty(currentUri)
                                                     ? SERVER_URI
                                                     : currentUri)
+                                    .maxInboundMessageSize(maxMessageSize)
                                     .usePlaintext()
                                     .build());
         }

--- a/lib/notification_service/java/src/main/java/org/aiflow/notification/conf/Configuration.java
+++ b/lib/notification_service/java/src/main/java/org/aiflow/notification/conf/Configuration.java
@@ -32,6 +32,13 @@ public class Configuration {
 
     public static final int CLIENT_INITIAL_SEQUENCE_NUMBER_CONFIG_DEFAULT_VALUE = 0;
 
+    /** Maximum message length of bytes that the channel can receive. */
+    public static final String GRPC_MAX_RECEIVE_MESSAGE_LENGTH_CONFIG_KEY =
+            "grpc.max_receive_message_length";
+
+    public static final int GRPC_MAX_RECEIVE_MESSAGE_LENGTH_CONFIG_DEFAULT_VALUE =
+            Integer.MAX_VALUE;
+
     private final Properties properties;
 
     public Configuration(Properties properties) {

--- a/lib/notification_service/java/src/test/java/org/aiflow/notification/service/PythonServer.java
+++ b/lib/notification_service/java/src/test/java/org/aiflow/notification/service/PythonServer.java
@@ -18,7 +18,7 @@ public class PythonServer {
         String serverScript = this.getClass().getResource("/notification_server.py").getFile();
         process =
                 new ProcessBuilder()
-                        .command("python", serverScript)
+                        .command("python3", serverScript)
                         .redirectErrorStream(true)
                         .start();
 


### PR DESCRIPTION
…e to unlimited.

<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

Set the maximum message length that the NotificationClient can receive to unlimited.


## Brief change log

*(for example:)*
  - Set the maximum message length that the NotificationClient can receive to unlimited.
  - Logging exception inner thread


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.
