### PR TITLE
[Notification] Waiting for notification server available after started

### DIFF
--- a/ai_flow_plugins/tests/airflow_scheduler_utils.py
+++ b/ai_flow_plugins/tests/airflow_scheduler_utils.py
@@ -30,7 +30,7 @@ from typing import Callable
 from notification_service.client import NotificationClient
 
 
-def start_scheduler(file_path, port=50051, executor=None):
+def start_scheduler(file_path, port=50052, executor=None):
     if executor is None:
         executor = LocalExecutor(15)
 
@@ -45,7 +45,7 @@ def start_scheduler(file_path, port=50051, executor=None):
     scheduler.run()
 
 
-def start_airflow_scheduler_server(file_path, port=50051) -> mp.Process:
+def start_airflow_scheduler_server(file_path, port=50052) -> mp.Process:
     mp.set_start_method('spawn')
     process = mp.Process(target=start_scheduler, args=(file_path, port))
     process.start()
@@ -74,7 +74,7 @@ def start_airflow_web_server() -> Popen:
     return sub_process
 
 
-def run_ai_flow_workflow(dag_id, test_function: Callable[[NotificationClient], None], port=50051, executor=None):
+def run_ai_flow_workflow(dag_id, test_function: Callable[[NotificationClient], None], port=50052, executor=None):
     def run_test_fun():
         time.sleep(5)
         client = NotificationClient(server_uri="localhost:{}".format(port),

--- a/lib/notification_service/notification_service/config_templates/default_notification_server.yaml
+++ b/lib/notification_service/notification_service/config_templates/default_notification_server.yaml
@@ -17,5 +17,10 @@
 
 # port of notification server
 server_port: 50052
+
 # uri of database backend for notification server
 db_uri: sqlite:///{NOTIFICATION_HOME}/ns.db
+
+# timeout for notification server to be available after started in seconds,
+# If not set, it will wait forever until server started
+# wait_for_server_started_timeout: 5.0

--- a/lib/notification_service/notification_service/server.py
+++ b/lib/notification_service/notification_service/server.py
@@ -125,7 +125,7 @@ class NotificationServerRunner(object):
         """
         Wait for server to be started and available.
 
-        :param timeout: Int value. Seconds to wait for server available.
+        :param timeout: Float value. Seconds to wait for server available.
                         If None, wait forever until server started.
         """
         server_uri = 'localhost:{}'.format(self.config.port)

--- a/lib/notification_service/notification_service/server.py
+++ b/lib/notification_service/notification_service/server.py
@@ -115,9 +115,27 @@ class NotificationServerRunner(object):
     def start(self, is_block=False):
         self._init_server()
         self.server.run(is_block)
+        if not is_block:
+            self._wait_for_server_available(timeout=self.config.wait_for_server_started_timeout)
 
     def stop(self):
         self.server.stop()
+
+    def _wait_for_server_available(self, timeout):
+        """
+        Wait for server to be started and available.
+
+        :param timeout: Int value. Seconds to wait for server available.
+                        If None, wait forever until server started.
+        """
+        server_uri = 'localhost:{}'.format(self.config.port)
+        try:
+            channel = grpc.insecure_channel(server_uri)
+            grpc.channel_ready_future(channel).result(timeout=timeout)
+            logging.info("Notification Server started successfully.")
+        except grpc.FutureTimeoutError as e:
+            logging.error('Notification Server is not available after waiting for {} seconds.'.format(timeout))
+            raise e
 
 
 def _loop(loop: asyncio.AbstractEventLoop):

--- a/lib/notification_service/notification_service/server_config.py
+++ b/lib/notification_service/notification_service/server_config.py
@@ -26,6 +26,7 @@ class NotificationServerConfig(object):
         self._enable_ha = False
         self._ha_ttl_ms = None
         self._advertised_uri = None
+        self._wait_for_server_started_timeout = None
         self._parse_config()
 
     def _parse_config(self):
@@ -41,6 +42,8 @@ class NotificationServerConfig(object):
                 self._ha_ttl_ms = yaml_config['ha_ttl_ms']
             if 'advertised_uri' in yaml_config:
                 self._advertised_uri = yaml_config['advertised_uri']
+            if 'wait_for_server_started_timeout' in yaml_config:
+                self._wait_for_server_started_timeout = yaml_config['wait_for_server_started_timeout']
 
     @property
     def port(self):
@@ -81,6 +84,14 @@ class NotificationServerConfig(object):
     @advertised_uri.setter
     def advertised_uri(self, advertised_uri):
         self._advertised_uri = advertised_uri
+
+    @property
+    def wait_for_server_started_timeout(self):
+        return self._wait_for_server_started_timeout
+
+    @wait_for_server_started_timeout.setter
+    def wait_for_server_started_timeout(self, wait_for_server_started_timeout):
+        self._wait_for_server_started_timeout = wait_for_server_started_timeout
 
 
 def get_configuration():

--- a/lib/notification_service/tests/notification_server.yaml
+++ b/lib/notification_service/tests/notification_server.yaml
@@ -25,3 +25,6 @@ enable_ha: false
 ha_ttl_ms: 10000
 # Hostname and port the server will advertise to clients when HA enabled. If not set, it will use the local ip and configured port.
 advertised_uri: 127.0.0.1:50052
+# timeout for notification server to be available after started in seconds,
+# If not set, it will wait forever until server started
+wait_for_server_started_timeout: 5.0

--- a/lib/notification_service/tests/test_notification_server.py
+++ b/lib/notification_service/tests/test_notification_server.py
@@ -54,6 +54,16 @@ class TestNotificationServer(unittest.TestCase):
         self.assertEqual('a', client.list_events(key='a')[0].value)
         server.stop()
 
+    def test__wait_for_server_available(self):
+        server = NotificationServerRunner(config_file=config_file)
+        from grpc import FutureTimeoutError
+        with self.assertRaises(FutureTimeoutError):
+            server._wait_for_server_available(timeout=1)
+        server.start()
+        server._wait_for_server_available(timeout=1)
+        server._wait_for_server_available(timeout=None)
+        server.stop()
+
     def test_run_ha_notification_server(self):
         server1 = NotificationServerRunner(config_file=config_file)
         server1.config.port = 50053

--- a/lib/notification_service/tests/test_notification_server.py
+++ b/lib/notification_service/tests/test_notification_server.py
@@ -55,12 +55,12 @@ class TestNotificationServer(unittest.TestCase):
         server.stop()
 
     def test__wait_for_server_available(self):
-        server = NotificationServerRunner(config_file=config_file)
         from grpc import FutureTimeoutError
+        server = NotificationServerRunner(config_file=config_file)
         with self.assertRaises(FutureTimeoutError):
-            server._wait_for_server_available(timeout=1)
+            server._wait_for_server_available(timeout=0.1)
         server.start()
-        server._wait_for_server_available(timeout=1)
+        server._wait_for_server_available(timeout=0.1)
         server._wait_for_server_available(timeout=None)
         server.stop()
 


### PR DESCRIPTION
<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

Waiting for notification server available after started


## Brief change log

*(for example:)*
  - Waiting for notification server available after started


## Verifying this change

*(Please pick either of the following options)*


This change added tests.