### PR TITLE
Waiting for AIFlow server available after started

### DIFF
--- a/ai_flow/config_templates/default_aiflow_server.yaml
+++ b/ai_flow/config_templates/default_aiflow_server.yaml
@@ -39,6 +39,10 @@ notification_server_uri: 127.0.0.1:50052
 # whether to start the scheduler service, default is True
 #start_scheduler_service: True
 
+# a float value represents seconds for AIFlow server to be available after started,
+# If not set, it will wait forever until server started
+# wait_for_server_started_timeout: 5.0
+
 # scheduler config
 scheduler_service:
   scheduler:

--- a/ai_flow/endpoint/server/server_config.py
+++ b/ai_flow/endpoint/server/server_config.py
@@ -127,6 +127,12 @@ class AIFlowServerConfig(AIFlowConfiguration):
     def get_web_server_config(self):
         return self.get('web_server')
 
+    def set_wait_for_server_started_timeout(self, wait_for_server_started_timeout):
+        self['wait_for_server_started_timeout'] = wait_for_server_started_timeout
+
+    def get_wait_for_server_started_timeout(self):
+        return self.get('wait_for_server_started_timeout')
+
 
 def get_configuration():
     if 'AIFLOW_HOME' in os.environ:

--- a/ai_flow/test/endpoint/server/test_server_runner.py
+++ b/ai_flow/test/endpoint/server/test_server_runner.py
@@ -89,6 +89,20 @@ class TestServerRunner(unittest.TestCase):
         server_runner.start(is_block=False)
         server_runner.stop()
 
+    def test__wait_for_server_available(self):
+        from grpc import FutureTimeoutError
+        server_runner = AIFlowServerRunner(config_file=os.path.dirname(__file__) + '/aiflow_server.yaml')
+
+        server_runner.server_config.set_wait_for_server_started_timeout(0)
+        with self.assertRaises(FutureTimeoutError):
+            server_runner.start()
+        server_runner.stop()
+
+        server_runner.server_config.set_wait_for_server_started_timeout(5)
+        server_runner.start()
+        server_runner._wait_for_server_available(timeout=0.1)
+        server_runner.stop()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

Waiting for AIFlow server available after started


## Brief change log

*(for example:)*
  - Waiting for AIFlow server available after started


## Verifying this change

*(Please pick either of the following options)*


This change added tests.