### PR TITLE
[AIFlow] Fix AIFlow server and webserver stop

### DIFF
--- a/ai_flow/cli/commands/server_command.py
+++ b/ai_flow/cli/commands/server_command.py
@@ -19,14 +19,14 @@ import datetime
 import logging
 import os
 import signal
-import time
+
+import daemon
+from daemon.pidfile import TimeoutPIDLockFile
 
 import ai_flow.settings
-import daemon
 from ai_flow import AIFlowServerRunner
 from ai_flow.settings import get_configuration_file_path
-from ai_flow.util.process_utils import check_pid_exist
-from daemon.pidfile import TimeoutPIDLockFile
+from ai_flow.util.process_utils import check_pid_exist, stop_process
 
 logger = logging.getLogger(__name__)
 
@@ -98,21 +98,9 @@ def server_stop(args):
     with open(pid_file_path, 'r') as f:
         pid = int(f.read())
 
-    try:
-        os.kill(pid, signal.SIGTERM)
-    except Exception:
-        logger.warning("Failed to stop AIFlow server (pid: {}) with SIGTERM. Try to send SIGKILL".format(pid))
-        try:
-            os.kill(pid, signal.SIGKILL)
-        except Exception as e:
-            raise RuntimeError("Failed to kill AIFlow server (pid: {}) with SIGKILL.".format(pid)) from e
+    if not check_pid_exist(pid):
+        logger.info("Process pid: {} does not exist. This means a staled PID file. Removing the PID file".format(pid))
+        os.remove(pid_file_path)
+        return
 
-    stop_timeout = 60
-    start_time = time.monotonic()
-    while check_pid_exist(pid):
-        if time.monotonic() - start_time > stop_timeout:
-            raise RuntimeError(
-                "AIFlow server (pid: {}) does not exit after {} seconds.".format(pid, stop_timeout))
-        time.sleep(0.5)
-
-    logger.info("AIFlow server pid: {} stopped".format(pid))
+    stop_process(pid, "AIFlow server")

--- a/ai_flow/cli/commands/webserver_command.py
+++ b/ai_flow/cli/commands/webserver_command.py
@@ -18,15 +18,14 @@
 import datetime
 import logging
 import os
-import signal
-import time
+
+import daemon
+from daemon.pidfile import TimeoutPIDLockFile
 
 import ai_flow.settings
-import daemon
 from ai_flow.frontend.web_server import start_web_server_by_config_file_path
 from ai_flow.settings import get_configuration_file_path
-from ai_flow.util.process_utils import check_pid_exist
-from daemon.pidfile import TimeoutPIDLockFile
+from ai_flow.util.process_utils import check_pid_exist, stop_process
 
 logger = logging.getLogger(__name__)
 
@@ -87,21 +86,9 @@ def webserver_stop(args):
     with open(pid_file_path, 'r') as f:
         pid = int(f.read())
 
-    try:
-        os.kill(pid, signal.SIGTERM)
-    except Exception:
-        logger.warning("Failed to stop AIFlow Webserver (pid: {}) with SIGTERM. Try to send SIGKILL".format(pid))
-        try:
-            os.kill(pid, signal.SIGKILL)
-        except Exception as e:
-            raise RuntimeError("Failed to kill AIFlow Webserver (pid: {}) with SIGKILL.".format(pid)) from e
+    if not check_pid_exist(pid):
+        logger.info("Process pid: {} does not exist. This means a staled PID file. Removing the PID file".format(pid))
+        os.remove(pid_file_path)
+        return
 
-    stop_timeout = 60
-    start_time = time.monotonic()
-    while check_pid_exist(pid):
-        if time.monotonic() - start_time > stop_timeout:
-            raise RuntimeError(
-                "AIFlow Webserver (pid: {}) does not exit after {} seconds.".format(pid, stop_timeout))
-        time.sleep(0.5)
-
-    logger.info("AIFlow Webserver pid: {} stopped".format(pid))
+    stop_process(pid, "AIFlow Webserver")

--- a/ai_flow/test/cli/commands/test_webserver_command.py
+++ b/ai_flow/test/cli/commands/test_webserver_command.py
@@ -16,13 +16,12 @@
 # under the License.
 import logging
 import os
-import signal
-import time
 import unittest
 from unittest import mock
 
-import ai_flow.settings
 import daemon
+
+import ai_flow.settings
 from ai_flow.cli import cli_parser
 from ai_flow.cli.commands import webserver_command
 
@@ -70,55 +69,28 @@ class TestCliServer(unittest.TestCase):
             log_output = "\n".join(log.output)
             self.assertIn("PID file of AIFlow Webserver does not exist at", log_output)
 
-    def test_cli_webserver_stop_SIGTERM_fail(self):
-        aiflow_home = os.path.join(os.path.dirname(__file__), "..")
-        ai_flow.settings.AIFLOW_HOME = aiflow_home
-        pid_file = os.path.join(aiflow_home, ai_flow.settings.AIFLOW_WEBSERVER_PID_FILENAME)
-        with mock.patch.object(os, "kill") as mock_kill, TmpPidFile(pid_file), \
-                mock.patch.object(webserver_command, "check_pid_exist") as mock_pid_check:
-            mock_kill.side_effect = [RuntimeError("Boom"), None]
-            mock_pid_check.side_effect = [False]
-            with self.assertLogs("ai_flow.cli.commands.webserver_command", "INFO") as log:
-                webserver_command.webserver_stop(self.parser.parse_args(['webserver', 'stop']))
-                log_output = "\n".join(log.output)
-                self.assertIn("Failed to stop AIFlow Webserver", log_output)
-                self.assertIn("stopped", log_output)
-
-    def test_cli_webserver_stop_SIGTERM_SIGKILL_fail(self):
-        aiflow_home = os.path.join(os.path.dirname(__file__), "..")
-        ai_flow.settings.AIFLOW_HOME = aiflow_home
-        pid_file = os.path.join(aiflow_home, ai_flow.settings.AIFLOW_WEBSERVER_PID_FILENAME)
-        with mock.patch.object(os, "kill") as mock_kill, TmpPidFile(pid_file):
-            mock_kill.side_effect = [RuntimeError("Boom"), RuntimeError("Boom")]
-            with self.assertLogs("ai_flow.cli.commands.webserver_command", "INFO") as log:
-                with self.assertRaises(RuntimeError):
-                    webserver_command.webserver_stop(self.parser.parse_args(['webserver', 'stop']))
-                log_output = "\n".join(log.output)
-                self.assertIn("Failed to stop AIFlow Webserver", log_output)
-
-    def test_cli_webserver_stop_wait_process_exit_timeout(self):
+    def test_cli_webserver_stop_with_staled_pid_file(self):
         aiflow_home = os.path.join(os.path.dirname(__file__), "..")
         ai_flow.settings.AIFLOW_HOME = aiflow_home
         pid_file = os.path.join(aiflow_home, ai_flow.settings.AIFLOW_WEBSERVER_PID_FILENAME)
 
-        with mock.patch.object(os, "kill") as mock_kill, \
-                TmpPidFile(pid_file), mock.patch.object(time, 'monotonic') as mock_monotonic:
-            mock_kill.return_value = True
-            mock_monotonic.side_effect = [0.0, 30.0, 70.0]
-            with self.assertRaises(RuntimeError):
-                webserver_command.webserver_stop(self.parser.parse_args(['server', 'stop']))
-            self.assertEqual(3, mock_monotonic.call_count)
+        with self.assertLogs("ai_flow", "INFO") as log, TmpPidFile(pid_file), \
+                mock.patch.object(webserver_command, "check_pid_exist") as mock_check_pid_exist:
+            mock_check_pid_exist.return_value = False
+            webserver_command.webserver_stop(self.parser.parse_args(['webserver', 'stop']))
+            log_output = "\n".join(log.output)
+            self.assertIn("This means a staled PID file.", log_output)
+            self.assertFalse(os.path.exists(pid_file))
 
     def test_cli_webserver_stop(self):
         aiflow_home = os.path.join(os.path.dirname(__file__), "..")
         ai_flow.settings.AIFLOW_HOME = aiflow_home
         pid_file = os.path.join(aiflow_home, ai_flow.settings.AIFLOW_WEBSERVER_PID_FILENAME)
-        with mock.patch.object(os, "kill") as mock_kill, TmpPidFile(pid_file), \
-                mock.patch.object(webserver_command, "check_pid_exist") as mock_pid_check:
-            mock_pid_check.side_effect = [True, False]
+        with TmpPidFile(pid_file), mock.patch.object(webserver_command, "stop_process") as mock_stop_process, \
+                mock.patch.object(webserver_command, "check_pid_exist") as mock_check_pid_exist:
+            mock_check_pid_exist.return_value = True
             webserver_command.webserver_stop(self.parser.parse_args(['webserver', 'stop']))
-            mock_kill.assert_called_once_with(15213, signal.SIGTERM)
-            self.assertEqual(2, mock_pid_check.call_count)
+            mock_stop_process.assert_called_with(15213, "AIFlow Webserver")
 
 
 class TmpPidFile:


### PR DESCRIPTION
<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

Fix AIFlow server and webserver stop


## Brief change log

- stop command sends SIGTERM to stop the process repeatedly until timeout or process exit.
- stop command check if the process exist first


## Verifying this change

This change added tests.