### PR TITLE
Stop workflow execution should check state before killing.

### DIFF
--- a/ai_flow_plugins/scheduler_plugins/airflow/airflow_scheduler.py
+++ b/ai_flow_plugins/scheduler_plugins/airflow/airflow_scheduler.py
@@ -238,7 +238,7 @@ class AirFlowScheduler(AirFlowSchedulerBase):
                 return WorkflowExecutionInfo(workflow_info=WorkflowInfo(namespace=project_name,
                                                                         workflow_name=workflow_name),
                                              workflow_execution_id=workflow_execution_id,
-                                             status=status.Status.FINISHED)
+                                             status=self.airflow_state_to_status(dagrun.state))
             context: ExecutionContext = ExecutionContext(dagrun_id=dagrun.run_id)
             current_context = self.airflow_client.stop_dag_run(dagrun.dag_id, context)
             return WorkflowExecutionInfo(workflow_info=WorkflowInfo(namespace=project_name,

--- a/ai_flow_plugins/scheduler_plugins/airflow/airflow_scheduler.py
+++ b/ai_flow_plugins/scheduler_plugins/airflow/airflow_scheduler.py
@@ -234,6 +234,11 @@ class AirFlowScheduler(AirFlowSchedulerBase):
             if dagrun is None:
                 return None
             project_name, workflow_name = self.dag_id_to_namespace_workflow(dagrun.dag_id)
+            if dagrun.state in State.finished:
+                return WorkflowExecutionInfo(workflow_info=WorkflowInfo(namespace=project_name,
+                                                                        workflow_name=workflow_name),
+                                             workflow_execution_id=workflow_execution_id,
+                                             status=status.Status.FINISHED)
             context: ExecutionContext = ExecutionContext(dagrun_id=dagrun.run_id)
             current_context = self.airflow_client.stop_dag_run(dagrun.dag_id, context)
             return WorkflowExecutionInfo(workflow_info=WorkflowInfo(namespace=project_name,

--- a/ai_flow_plugins/tests/scheduler_plugins/airflow/test_airflow_scheduler.py
+++ b/ai_flow_plugins/tests/scheduler_plugins/airflow/test_airflow_scheduler.py
@@ -25,6 +25,7 @@ import cloudpickle
 from ai_flow.api.context_extractor import BroadcastAllContextExtractor
 from ai_flow.context.project_context import ProjectContext
 from ai_flow.project.project_config import ProjectConfig
+from ai_flow.workflow.status import Status
 from ai_flow.workflow.workflow import Workflow
 from ai_flow.workflow.workflow_config import WorkflowConfig
 from ai_flow_plugins.scheduler_plugins.airflow.airflow_scheduler import AirFlowScheduler
@@ -121,6 +122,20 @@ class TestAirflowScheduler(unittest.TestCase):
 
         finally:
             os.remove(context_extractor_path)
+
+    @patch('ai_flow_plugins.scheduler_plugins.airflow.airflow_scheduler.create_session')
+    def test_airflow_scheduler_kill_workflow_execution(self, mock_session):
+        from airflow.models import DagRun
+        from airflow.utils.state import State
+        mock_session.return_value.__enter__.return_value.query.return_value.filter.return_value.first.return_value = \
+            DagRun(dag_id='dag1.run1', state=State.FAILED)
+
+        workflow_execution = self.scheduler.stop_workflow_execution(workflow_execution_id='1')
+        self.assertEquals(Status.FINISHED, workflow_execution.status)
+
+        mock_session.return_value.__enter__.return_value.query.return_value.filter.\
+            return_value.first.return_value = DagRun(dag_id='dag1.run1', state=State.RUNNING)
+        self.assertEquals(Status.FINISHED, workflow_execution.status)
 
     @staticmethod
     def _get_project_context(project_name):

--- a/ai_flow_plugins/tests/scheduler_plugins/airflow/test_airflow_scheduler.py
+++ b/ai_flow_plugins/tests/scheduler_plugins/airflow/test_airflow_scheduler.py
@@ -131,11 +131,12 @@ class TestAirflowScheduler(unittest.TestCase):
             DagRun(dag_id='dag1.run1', state=State.FAILED)
 
         workflow_execution = self.scheduler.stop_workflow_execution(workflow_execution_id='1')
-        self.assertEquals(Status.FINISHED, workflow_execution.status)
+        self.assertEquals(Status.FAILED, workflow_execution.status)
 
         mock_session.return_value.__enter__.return_value.query.return_value.filter.\
             return_value.first.return_value = DagRun(dag_id='dag1.run1', state=State.RUNNING)
-        self.assertEquals(Status.FINISHED, workflow_execution.status)
+        workflow_execution = self.scheduler.stop_workflow_execution(workflow_execution_id='1')
+        self.assertEquals(Status.KILLED, workflow_execution.status)
 
     @staticmethod
     def _get_project_context(project_name):


### PR DESCRIPTION
<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

Fix #137 


## Brief change log

*(for example:)*
  - Stop workflow execution should check state before killing.


## Verifying this change

This change added tests.