### PR TITLE
[bug-fix] State of dagrun should not be failed if one of tasks is killed

### DIFF
--- a/lib/airflow/airflow/utils/state.py
+++ b/lib/airflow/airflow/utils/state.py
@@ -142,7 +142,7 @@ class State:
     a run or has not even started.
     """
 
-    failed_states = frozenset([FAILED, UPSTREAM_FAILED, KILLED])
+    failed_states = frozenset([FAILED, UPSTREAM_FAILED])
     """
     A list of states indicating that a task or dag is a failed state.
     """


### PR DESCRIPTION
<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

Fix https://github.com/flink-extended/ai-flow/issues/245
State of dagrun should not be failed if one of tasks is killed


## Brief change log

*(for example:)*
  - State of dagrun should not be failed if one of tasks is killed


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.
