### PR TITLE
BaseExecutor should not send TaskStateChangedEvent after stop task

### DIFF
--- a/lib/airflow/airflow/executors/base_executor.py
+++ b/lib/airflow/airflow/executors/base_executor.py
@@ -153,8 +153,7 @@ class BaseExecutor(LoggingMixin):
                     self._send_message(ti)
             elif SchedulingAction.STOP == action:
                 if ti.state in State.unfinished:
-                    if self._stop_task_instance(key):
-                        self._send_message(ti)
+                    self._stop_task_instance(key)
             elif SchedulingAction.RESTART == action:
                 if ti.state in State.running:
                     self._restart_task_instance(key)


### PR DESCRIPTION
<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

fix #247 


## Brief change log

*(for example:)*
  - BaseExecutor should not send TaskStateChangedEvent after stop task

## Verifying this change

*(Please pick either of the following options)*

This change is already covered by existing tests, such as *(please describe tests)*.
