### PR TITLE
[Bugfix] Workflow execution end date not updated

### DIFF
--- a/ai_flow/metadata/workflow_execution.py
+++ b/ai_flow/metadata/workflow_execution.py
@@ -14,6 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from datetime import datetime
+
 from sqlalchemy import Column, String, Integer, DateTime, ForeignKey, BigInteger
 from sqlalchemy.orm import relationship
 
@@ -60,7 +62,7 @@ class WorkflowExecutionMeta(Base):
         self.workflow_id = workflow_id
         self.run_type = run_type
         self.snapshot_id = snapshot_id
-        self.begin_date = begin_date
+        self.begin_date = datetime.now() if begin_date is None else begin_date
         self.end_date = end_date
         self.status = status
         self.event_offset = event_offset

--- a/ai_flow/scheduler/scheduling_event_processor.py
+++ b/ai_flow/scheduler/scheduling_event_processor.py
@@ -145,9 +145,8 @@ class SchedulingEventProcessor(object):
             task_execution = self.metadata_manager.get_latest_task_execution(
                 workflow_execution_id=workflow_execution_id,
                 task_name=task_name)
-            if task_execution is None:
-                return
-            task_executions.append(task_execution)
+            if task_execution is not None:
+                task_executions.append(task_execution)
         is_success = True
         for te in task_executions:
             if TaskStatus(te.status) == TaskStatus.FAILED:

--- a/ai_flow/scheduler/scheduling_event_processor.py
+++ b/ai_flow/scheduler/scheduling_event_processor.py
@@ -108,7 +108,8 @@ class SchedulingEventProcessor(object):
                     task_execution_id=task_execution_meta.id,
                     status=status)
                 self.metadata_manager.flush()
-                self._set_workflow_execution_status(workflow_execution_id=workflow_execution_id)
+                if TaskStatus(status) in TASK_FINISHED_SET:
+                    self._set_workflow_execution_status(workflow_execution_id=workflow_execution_id)
 
         elif SchedulingEventType.TASK_HEARTBEAT_TIMEOUT == scheduling_event_type:
             workflow_execution_id = context[EventContextConstant.WORKFLOW_EXECUTION_ID]
@@ -134,8 +135,6 @@ class SchedulingEventProcessor(object):
         workflow_execution = \
             self.metadata_manager.get_workflow_execution(workflow_execution_id=workflow_execution_id)
         workflow: Workflow = cloudpickle.loads(workflow_execution.workflow_snapshot.workflow_object)
-        if workflow.rules is not None and len(workflow.rules) != 0:
-            return
         for op in workflow.tasks.values():
             if OperatorConfigItem.PERIODIC_EXPRESSION in op.config \
                     and op.config[OperatorConfigItem.PERIODIC_EXPRESSION] is not None:
@@ -146,6 +145,8 @@ class SchedulingEventProcessor(object):
             task_execution = self.metadata_manager.get_latest_task_execution(
                 workflow_execution_id=workflow_execution_id,
                 task_name=task_name)
+            if task_execution is None:
+                return
             task_executions.append(task_execution)
         is_success = True
         for te in task_executions:


### PR DESCRIPTION
<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

*(For example: This pull request makes user can stop workflow externally.)*


## Brief change log

*(for example:)*
  - *Send StopDagEvent to Airflow scheduler via notification service*
  - *Once received StopDagEvent, Airflow scheduler kills all running dag runs*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests.