### PR TITLE
Start Task/Workflow execution should return an id

### DIFF
--- a/ai_flow/cli/commands/task_execution_command.py
+++ b/ai_flow/cli/commands/task_execution_command.py
@@ -27,8 +27,8 @@ from ai_flow.cli.simple_table import AIFlowConsole
 def start_task_execution(args):
     workflow_execution_id = int(args.workflow_execution_id)
     task_name = args.task_name
-    ops.start_task_execution(workflow_execution_id=workflow_execution_id, task_name=task_name)
-    print(f"Submitting a new execution of task: {task_name} of workflow execution: {workflow_execution_id}.")
+    key = ops.start_task_execution(workflow_execution_id=workflow_execution_id, task_name=task_name)
+    print(f"Task execution: {key} submitted.")
 
 
 def stop_task_execution(args):

--- a/ai_flow/cli/commands/workflow_execution_command.py
+++ b/ai_flow/cli/commands/workflow_execution_command.py
@@ -27,9 +27,8 @@ from ai_flow.cli.simple_table import AIFlowConsole
 def start_workflow_execution(args):
     namespace = args.namespace if args.namespace is not None else 'default'
     workflow_name = args.workflow_name
-    ops.start_workflow_execution(workflow_name=workflow_name,
-                                 namespace=namespace)
-    print(f"Submitting a new execution of Workflow: {namespace}.{workflow_name}.")
+    execution_id = ops.start_workflow_execution(workflow_name=workflow_name, namespace=namespace)
+    print(f"Workflow execution: {execution_id} submitted.")
 
 
 def stop_workflow_execution(args):

--- a/ai_flow/metadata/metadata_manager.py
+++ b/ai_flow/metadata/metadata_manager.py
@@ -618,6 +618,7 @@ class MetadataManager(object):
 
         workflow = cloudpickle.loads(meta.workflow_snapshot.workflow_object)
         if WorkflowStatus(status) == WorkflowStatus.RUNNING:
+            meta.begin_date = datetime.now()
             for task_name, task in workflow.tasks.items():
                 if OperatorConfigItem.PERIODIC_EXPRESSION in task.config \
                         and task.config[OperatorConfigItem.PERIODIC_EXPRESSION] is not None:

--- a/ai_flow/metadata/workflow_execution.py
+++ b/ai_flow/metadata/workflow_execution.py
@@ -62,7 +62,7 @@ class WorkflowExecutionMeta(Base):
         self.workflow_id = workflow_id
         self.run_type = run_type
         self.snapshot_id = snapshot_id
-        self.begin_date = datetime.now() if begin_date is None else begin_date
+        self.begin_date = begin_date
         self.end_date = end_date
         self.status = status
         self.event_offset = event_offset

--- a/ai_flow/ops/task_execution_ops.py
+++ b/ai_flow/ops/task_execution_ops.py
@@ -26,17 +26,18 @@ logger = logging.getLogger(__name__)
 
 
 def start_task_execution(workflow_execution_id: int,
-                         task_name: str):
+                         task_name: str) -> str:
     """
-    Asynchronously start a new execution of the task.
+    Start a new execution of the task.
 
     :param workflow_execution_id: The workflow execution contains the task.
     :param task_name: The name of the task to be started.
+    :return: The TaskExecutionKey str.
     :raises: AIFlowException if failed to start task execution.
     """
     client = get_scheduler_client()
     try:
-        client.start_task_execution(workflow_execution_id, task_name)
+        return client.start_task_execution(workflow_execution_id, task_name)
     except AIFlowException as e:
         logger.exception("Failed to start execution for task %s with exception %s",
                          f'{workflow_execution_id}.{task_name}', str(e))

--- a/ai_flow/ops/workflow_execution_ops.py
+++ b/ai_flow/ops/workflow_execution_ops.py
@@ -26,17 +26,18 @@ logger = logging.getLogger(__name__)
 
 
 def start_workflow_execution(workflow_name: str,
-                             namespace: str = 'default'):
+                             namespace: str = 'default') -> int:
     """
-    Asynchronously start a new execution of the workflow.
+    Start a new execution of the workflow.
 
     :param workflow_name: The workflow to be executed.
     :param namespace: The namespace which contains the workflow.
+    :return: Id of the workflow execution just started.
     :raises: AIFlowException if failed to start workflow execution.
     """
     client = get_scheduler_client()
     try:
-        client.start_workflow_execution(workflow_name, namespace)
+        return client.start_workflow_execution(workflow_name, namespace)
     except AIFlowException as e:
         logger.exception("Failed to start execution for workflow %s with exception %s",
                          f'{namespace}.{workflow_name}', str(e))

--- a/ai_flow/rpc/client/scheduler_client.py
+++ b/ai_flow/rpc/client/scheduler_client.py
@@ -38,7 +38,7 @@ from ai_flow.rpc.client.util.response_unwrapper import unwrap_workflow_list_resp
     unwrap_workflow_schedule_response, unwrap_workflow_schedule_list_response, \
     unwrap_workflow_trigger_response, unwrap_workflow_trigger_list_response, unwrap_task_execution_response, \
     unwrap_task_execution_list_response, unwrap_workflow_snapshot_response, unwrap_workflow_snapshot_list_response, \
-    unwrap_namespace_response, unwrap_namespace_list_response
+    unwrap_namespace_response, unwrap_namespace_list_response, unwrap_string_response
 from ai_flow.rpc.protobuf import scheduler_service_pb2_grpc
 from ai_flow.rpc.protobuf.message_pb2 import WorkflowIdentifier, WorkflowProto, IdRequest, WorkflowScheduleProto, \
     WorkflowTriggerProto, TaskExecutionIdentifier, WorkflowSnapshotProto, NamespaceProto, NameRequest, ListRequest
@@ -153,10 +153,10 @@ class SchedulerClient(object):
         response = self.scheduler_stub.deleteWorkflowSnapshots(request)
         return unwrap_bool_response(response)
 
-    def start_workflow_execution(self, workflow_name, namespace) -> bool:
+    def start_workflow_execution(self, workflow_name, namespace) -> int:
         request = WorkflowIdentifier(namespace=namespace, workflow_name=workflow_name)
         response = self.scheduler_stub.startWorkflowExecution(request)
-        return unwrap_bool_response(response)
+        return int(unwrap_string_response(response))
 
     def stop_workflow_execution(self, workflow_execution_id) -> bool:
         request = IdRequest(id=workflow_execution_id)
@@ -185,11 +185,11 @@ class SchedulerClient(object):
         response = self.scheduler_stub.listWorkflowExecutions(request)
         return unwrap_workflow_execution_list_response(response)
 
-    def start_task_execution(self, workflow_execution_id, task_name) -> bool:
+    def start_task_execution(self, workflow_execution_id, task_name) -> str:
         request = TaskExecutionIdentifier(workflow_execution_id=workflow_execution_id,
                                           task_name=task_name)
         response = self.scheduler_stub.startTaskExecution(request)
-        return unwrap_bool_response(response)
+        return unwrap_string_response(response)
 
     def stop_task_execution(self, workflow_execution_id, task_name) -> bool:
         request = TaskExecutionIdentifier(workflow_execution_id=workflow_execution_id,

--- a/ai_flow/scheduler/worker.py
+++ b/ai_flow/scheduler/worker.py
@@ -141,7 +141,9 @@ class Worker(threading.Thread):
                     self._last_committed_offset = event.offset
                 except Exception as e:
                     session.rollback()
-                    logging.exception("Can not handle event: {}, exception: {}".format(str(event), str(e)))
+                    logging.exception(
+                        "Can not handle event: {}, exception: {}, put back in the queue".format(str(event), str(e)))
+                    self.add_unit((event, rule))
                 finally:
                     self.input_queue.task_done()
 


### PR DESCRIPTION
<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

*(For example: This pull request makes user can stop workflow externally.)*


## Brief change log

*(for example:)*
  - *Send StopDagEvent to Airflow scheduler via notification service*
  - *Once received StopDagEvent, Airflow scheduler kills all running dag runs*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests.