### PR TITLE
[Fix 357] TaskExecution with status QUEUED cannot be stopped

### DIFF
--- a/ai_flow/cli/commands/task_manager_command.py
+++ b/ai_flow/cli/commands/task_manager_command.py
@@ -84,13 +84,11 @@ class TaskManager(object):
 
     def run_task(self):
         try:
-            self._send_task_status_change(TaskStatus.RUNNING)
             self._execute()
         except TaskFailedException:
             self._send_task_status_change(TaskStatus.FAILED)
             raise
         except TaskForceStoppedException:
-            self._send_task_status_change(TaskStatus.STOPPED)
             raise
         else:
             self._send_task_status_change(TaskStatus.SUCCESS)

--- a/ai_flow/common/util/process_utils.py
+++ b/ai_flow/common/util/process_utils.py
@@ -62,6 +62,8 @@ def stop_process(pid, timeout_sec: int = 60):
                 raise RuntimeError(
                     "pid: {} does not exit after {} seconds.".format(pid, timeout_sec))
             time.sleep(1)
+    except ProcessLookupError:
+        pass
     except Exception:
         logger.warning("Failed to stop pid: {} with SIGTERM. Try to send SIGKILL".format(pid))
         try:

--- a/tests/task_executor/local/test_local_task_executor.py
+++ b/tests/task_executor/local/test_local_task_executor.py
@@ -75,8 +75,9 @@ class TestLocalExecutor(unittest.TestCase):
                 psutil.Process(process.pid)
 
     @mock.patch.object(config_constants, 'TASK_EXECUTOR_HEARTBEAT_CHECK_INTERVAL', 1)
-    @mock.patch('ai_flow.task_executor.common.heartbeat_manager.EmbeddedNotificationClient')
-    def test_negative_parallelism(self, mock_ns):
+    @mock.patch('ai_flow.task_executor.common.task_executor_base.HeartbeatManager')
+    @mock.patch('ai_flow.task_executor.common.task_executor_base.EmbeddedNotificationClient')
+    def test_negative_parallelism(self, mock_ns, mock_heartbeat):
         with self.assertRaises(AIFlowException) as context:
             try:
                 executor = LocalTaskExecutor(0)


### PR DESCRIPTION
<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

*(For example: This pull request makes user can stop workflow externally.)*


## Brief change log

*(for example:)*
  - *Send StopDagEvent to Airflow scheduler via notification service*
  - *Once received StopDagEvent, Airflow scheduler kills all running dag runs*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests.