### PR TITLE
[hotfix] fix typo of spark operator

### DIFF
--- a/ai_flow/operators/spark/spark_submit.py
+++ b/ai_flow/operators/spark/spark_submit.py
@@ -165,7 +165,7 @@ class SparkSubmitOperator(AIFlowOperator):
         if self._executable_path:
             spark_submit = self._executable_path
         elif shutil.which('spark-submit') is not None:
-            spark_submit = shutil.which('spark_submit')
+            spark_submit = shutil.which('spark-submit')
             self.log.info(f"Using {spark_submit} in PATH")
         else:
             spark_submit = expand_env_var('${SPARK_HOME}/bin/spark-submit')


### PR DESCRIPTION
<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

*(For example: This pull request makes user can stop workflow externally.)*


## Brief change log

*(for example:)*
  - *Send StopDagEvent to Airflow scheduler via notification service*
  - *Once received StopDagEvent, Airflow scheduler kills all running dag runs*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests.